### PR TITLE
Update model.md

### DIFF
--- a/aspnetcore/tutorials/razor-pages/model.md
+++ b/aspnetcore/tutorials/razor-pages/model.md
@@ -13,13 +13,12 @@ ms.contentlocale: zh-CN
 ms.lasthandoff: 01/22/2019
 ms.locfileid: "54444099"
 ---
-# <a name="add-a-model-to-a-razor-pages-app-in-aspnet-core"></a>在 ASP.NET Core 中向 Razor 页面应用添加模型
-
+# <a name="add-a-model-to-a-razor-pages-app-in-aspnet-core"></a>在 ASP.NET Core 中向 Razor Pages 应用添加模型
 作者：[Rick Anderson](https://twitter.com/RickAndMSFT)
 
 [!INCLUDE[](~/includes/rp/download.md)]
 
-在此部分中，添加了用于管理数据库中的电影的类。 可以结合 [Entity Framework Core](/ef/core) (EF Core) 使用这些类来处理数据库。 EF Core 是对象关系映射 (ORM) 框架，可以简化数据访问代码。
+在本节中，添加了用于管理数据库中的电影的类。 这些类与 [Entity Framework Core](/ef/core)（EF Core）一起使用来处理数据库。 EF Core 是一种对象关系映射 (ORM) 框架，可以简化数据访问代码。
 
 模型类称为 POCO 类（源自“简单传统 CLR 对象”），因为它们与 EF Core 没有任何依赖关系。 它们定义数据库中存储的数据属性。
 
@@ -41,7 +40,7 @@ ms.locfileid: "54444099"
 
 # <a name="visual-studio-codetabvisual-studio-code"></a>[Visual Studio Code](#tab/visual-studio-code)
 
-* 添加名为“模型”的文件夹。
+* 添加名为“Models”的文件夹。
 * 将类添加到名为“Movie.cs”的“Models”文件夹。
 
 [!INCLUDE [model 1b](~/includes/RP/model1b.md)]
@@ -148,7 +147,7 @@ appsettings.json 文件通过用于连接到本地数据的连接字符串进行
 
 ---
 
-前面的命令生成以下警告：“未对实体类型‘Movie’上的十进制列‘Price’指定任何类型。 当值不符合默认精确度和小数位数时，会在无提示的情况下截断该值。 使用‘HasColumnType()’显式指定可以容纳所有值的 SQL Server 列类型。”
+前面的命令生成以下警告：“No type was specified for the decimal column 'Price' on entity type 'Movie'. This will cause values to be silently truncated if they do not fit in the default precision and scale. Explicitly specify the SQL server column type that can accommodate all the values using 'HasColumnType()'.”
 
 你可以忽略该警告，它将后面的教程中得到修复。
 
@@ -163,7 +162,7 @@ appsettings.json 文件通过用于连接到本地数据的连接字符串进行
 
 * *Startup.cs*
 
-下一部分中说明了创建和更新的文件。
+创建和更新的文件将在下一节中说明。
 
 <a name="pmc"></a>
 


### PR DESCRIPTION
1.“未对实体类型‘Movie’上的十进制列‘Price’指定任何类型。 当值不符合默认精确度和小数位数时，会在无提示的情况下截断该值。 使用‘HasColumnType()’显式指定可以容纳所有值的 SQL Server 列类型。”
不需要翻译，这部分在终端中输出的是英文。

2.vs code部分，创建的是models文件夹，不需要翻译为模型文件夹。